### PR TITLE
Name instead of ID

### DIFF
--- a/PhysicalTherapy/PhyscialTherapy/Client/src/app/therapist-home-screen/therapist-home-screen.component.html
+++ b/PhysicalTherapy/PhyscialTherapy/Client/src/app/therapist-home-screen/therapist-home-screen.component.html
@@ -28,7 +28,7 @@
           <td><ngb-highlight class="font-weight-bold" [result]="routine.routineId"></ngb-highlight></td>
           <td><ngb-highlight [result]="routine.date | date"></ngb-highlight></td>
           <td><a routerLink="/routine-page">{{routine.name}}</a></td>
-          <td>{{routine.patientId}}</td>
+          <td>{{routine.patient.firstName}} {{routine.patient.lastName}}</td>
           <td>{{routine.description}}</td>
         </tr>
       </tbody>
@@ -57,9 +57,10 @@
     <table class="table table-striped shadow border">
       <thead class="h3">
         <tr>
-          <th scope="col">Id #</th>
+          <th scope="col">Name</th>
           <th scope="col">Date</th>
           <th scope="col">Name</th>
+          <th scope="col">Patient</th>
           <th scope="col">Description</th>
         </tr>
       </thead>
@@ -69,6 +70,7 @@
           <td><ngb-highlight class="font-weight-bold" [result]="routine.routineId"></ngb-highlight></td>
           <td><ngb-highlight [result]="routine.date | date"></ngb-highlight></td>
           <td><a routerLink="/routine-page">{{routine.name}}</a></td>
+          <td>{{routine.patient.firstName}} {{routine.patient.lastName}}</td>
           <td>{{routine.description}}</td>
         </tr>
       </tbody>

--- a/PhysicalTherapy/PhyscialTherapy/Client/src/app/therapist-home-screen/therapist-home-screen.component.html
+++ b/PhysicalTherapy/PhyscialTherapy/Client/src/app/therapist-home-screen/therapist-home-screen.component.html
@@ -15,7 +15,7 @@
     <table class="table table-striped shadow border" >
       <thead class="h3">
         <tr>
-          <th scope="col">Id #</th>
+          <th scope="col">ID #</th>
           <th scope="col">Date</th>
           <th scope="col">Name</th>
           <th scope="col">Patient</th>
@@ -57,7 +57,7 @@
     <table class="table table-striped shadow border">
       <thead class="h3">
         <tr>
-          <th scope="col">Name</th>
+          <th scope="col">ID #</th>
           <th scope="col">Date</th>
           <th scope="col">Name</th>
           <th scope="col">Patient</th>

--- a/PhysicalTherapy/PhyscialTherapy/Client/src/app/therapist-roster/therapist-roster.component.html
+++ b/PhysicalTherapy/PhyscialTherapy/Client/src/app/therapist-roster/therapist-roster.component.html
@@ -19,7 +19,7 @@
           <th scope="col">Id #</th>
           <th scope="col">First Name</th>
           <th scope="col">Last Name</th>
-          <th scope="col">Therapist Id</th>
+          <th scope="col">Therapist</th>
         </tr>
       </thead>
 
@@ -28,7 +28,7 @@
           <td><ngb-highlight class="font-weight-bold" [result]="patient.patientId"></ngb-highlight></td>
           <td><ngb-highlight [result]="patient.firstName"></ngb-highlight></td>
           <td><ngb-highlight [result]="patient.lastName"></ngb-highlight></td>
-          <td>{{patient.therapistId}}</td>
+          <td>{{patient.therapist.firstName}}</td>
         </tr>
       </tbody>
     </table>

--- a/PhysicalTherapy/PhyscialTherapy/Client/src/app/therapist-roster/therapist-roster.component.html
+++ b/PhysicalTherapy/PhyscialTherapy/Client/src/app/therapist-roster/therapist-roster.component.html
@@ -28,7 +28,7 @@
           <td><ngb-highlight class="font-weight-bold" [result]="patient.patientId"></ngb-highlight></td>
           <td><ngb-highlight [result]="patient.firstName"></ngb-highlight></td>
           <td><ngb-highlight [result]="patient.lastName"></ngb-highlight></td>
-          <td>{{patient.therapist.firstName}}</td>
+          <td>{{patient.therapist.firstName}} {{patient.therapist.lastName}}</td>
         </tr>
       </tbody>
     </table>

--- a/PhysicalTherapy/PhyscialTherapy/Repositories/PatientRepository.cs
+++ b/PhysicalTherapy/PhyscialTherapy/Repositories/PatientRepository.cs
@@ -46,13 +46,15 @@ namespace PhysicalTherapy.Repositories
 
         public IEnumerable<Patient> GetAll()
         {
-            return _context.Patients;
+            return _context.Patients
+                .Include(p => p.Therapist);
         }
 
         public IEnumerable<Patient> GetByTherapistId(int id)
         {
             return _context.Patients
-                .Where(b => b.TherapistId.Equals(id));
+                .Where(b => b.TherapistId.Equals(id))
+                .Include(p => p.Therapist);
         }
 
         public IEnumerable<Patient> GetLatePatientsByTherapistId(int id)


### PR DESCRIPTION
Just makes more sense to have the therapist/patient name instead of the id. Changes were pretty simple after I figured out why the Therpist was coming back null for the roster.