### PR TITLE
Display all data on therapist home tables

### DIFF
--- a/PhysicalTherapy/PhyscialTherapy/Client/src/app/add-patient/add-patient.component.html
+++ b/PhysicalTherapy/PhyscialTherapy/Client/src/app/add-patient/add-patient.component.html
@@ -36,7 +36,7 @@
                 <tr>
                     <td></td><td></td><td></td>
                     <td valign="bottom" align="right">
-                        <button id="addPatients" (click)="addPatient()">ADD</button>
+                        <button class="btn btn-outline-primary mr-2" id="addPatients" (click)="addPatient()">ADD</button>
                     </td>
                 </tr>
             </tfoot>

--- a/PhysicalTherapy/PhyscialTherapy/Client/src/app/therapist-home-screen/therapist-home-screen.component.html
+++ b/PhysicalTherapy/PhyscialTherapy/Client/src/app/therapist-home-screen/therapist-home-screen.component.html
@@ -12,27 +12,29 @@
   </div>
 
   <form id="feedForm" >
-    <table class="table table-striped shadow border" >
-      <thead class="h3">
-        <tr>
-          <th scope="col">ID #</th>
-          <th scope="col">Date</th>
-          <th scope="col">Name</th>
-          <th scope="col">Patient</th>
-          <th scope="col">Description</th>
-        </tr>
-      </thead>
+    <div style="overflow: scroll; height: 250px">
+      <table class="table table-striped shadow border" >
+        <thead class="h3">
+          <tr>
+            <th scope="col">ID #</th>
+            <th scope="col">Date</th>
+            <th scope="col">Name</th>
+            <th scope="col">Patient</th>
+            <th scope="col">Description</th>
+          </tr>
+        </thead>
 
-      <tbody>
-        <tr *ngFor="let routine of filteredfeedback">
-          <td><ngb-highlight class="font-weight-bold" [result]="routine.routineId"></ngb-highlight></td>
-          <td><ngb-highlight [result]="routine.date | date"></ngb-highlight></td>
-          <td><a routerLink="/routine-page">{{routine.name}}</a></td>
-          <td>{{routine.patient.firstName}} {{routine.patient.lastName}}</td>
-          <td>{{routine.description}}</td>
-        </tr>
-      </tbody>
-    </table>
+        <tbody>
+          <tr *ngFor="let routine of filteredfeedback">
+            <td><ngb-highlight class="font-weight-bold" [result]="routine.routineId"></ngb-highlight></td>
+            <td><ngb-highlight [result]="routine.date | date"></ngb-highlight></td>
+            <td><a routerLink="/routine-page">{{routine.name}}</a></td>
+            <td>{{routine.patient.firstName}} {{routine.patient.lastName}}</td>
+            <td>{{routine.description}}</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
   </form>
 
   <!---div class="d-flex justify-content-between p-2" id="paging1">
@@ -54,27 +56,29 @@
   </div>
   
   <form id="lateForm" >
-    <table class="table table-striped shadow border">
-      <thead class="h3">
-        <tr>
-          <th scope="col">ID #</th>
-          <th scope="col">Date</th>
-          <th scope="col">Name</th>
-          <th scope="col">Patient</th>
-          <th scope="col">Description</th>
-        </tr>
-      </thead>
+    <div style="overflow: scroll; height: 250px">
+      <table class="table table-striped shadow border">
+        <thead class="h3">
+          <tr>
+            <th scope="col">ID #</th>
+            <th scope="col">Date</th>
+            <th scope="col">Name</th>
+            <th scope="col">Patient</th>
+            <th scope="col">Description</th>
+          </tr>
+        </thead>
 
-      <tbody>
-        <tr *ngFor="let routine of filteredlate">
-          <td><ngb-highlight class="font-weight-bold" [result]="routine.routineId"></ngb-highlight></td>
-          <td><ngb-highlight [result]="routine.date | date"></ngb-highlight></td>
-          <td><a routerLink="/routine-page">{{routine.name}}</a></td>
-          <td>{{routine.patient.firstName}} {{routine.patient.lastName}}</td>
-          <td>{{routine.description}}</td>
-        </tr>
-      </tbody>
-    </table>
+        <tbody>
+          <tr *ngFor="let routine of filteredlate">
+            <td><ngb-highlight class="font-weight-bold" [result]="routine.routineId"></ngb-highlight></td>
+            <td><ngb-highlight [result]="routine.date | date"></ngb-highlight></td>
+            <td><a routerLink="/routine-page">{{routine.name}}</a></td>
+            <td>{{routine.patient.firstName}} {{routine.patient.lastName}}</td>
+            <td>{{routine.description}}</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
   </form>
 
   <!--div class="d-flex justify-content-between p-2" id="paging2">

--- a/PhysicalTherapy/PhyscialTherapy/Client/src/app/therapist-home-screen/therapist-home-screen.component.ts
+++ b/PhysicalTherapy/PhyscialTherapy/Client/src/app/therapist-home-screen/therapist-home-screen.component.ts
@@ -79,7 +79,7 @@ export class TherapistHomeScreenComponent implements OnInit {
     this.feedbackSize = this.filteredFeedback.length;
     return this.filteredFeedback
       .map((r, i) => ({id: i + 1, ...r}))
-      .slice((this.page - 1) * this.pageSize, (this.page - 1) * this.pageSize + this.pageSize);
+      //.slice((this.page - 1) * this.pageSize, (this.page - 1) * this.pageSize + this.pageSize);
   }
 
   get lateListFilter() : string {
@@ -104,7 +104,7 @@ export class TherapistHomeScreenComponent implements OnInit {
     this.lateSize = this.filteredLate.length;
     return this.filteredLate
       .map((r, i) => ({id: i + 1, ...r}))
-      .slice((this.page - 1) * this.pageSize, (this.page - 1) * this.pageSize + this.pageSize);
+      //.slice((this.page - 1) * this.pageSize, (this.page - 1) * this.pageSize + this.pageSize);
   }
 
 }


### PR DESCRIPTION
All the data for feedback and late patients should display in the tables now and there is a scroll bar to move through the table. Also added bootstrap to a button on the add patient page.